### PR TITLE
fix items length bug

### DIFF
--- a/lib/src/story_presenter/story_view.dart
+++ b/lib/src/story_presenter/story_view.dart
@@ -40,7 +40,7 @@ class FlutterStoryView extends StatefulWidget {
       this.onSlideDown,
       this.onSlideStart,
       super.key})
-      : assert(initialIndex < items.length - 1);
+      : assert(initialIndex < items.length);
 
   /// List of StoryItem objects to display in the story view.
   final List<StoryItem> items;


### PR DESCRIPTION
for list with 1 item the condition throws exception. (init index  = 0 ) < (items.length - 1 ) how it can be done